### PR TITLE
Include repo name in plugin search

### DIFF
--- a/tools/reckless
+++ b/tools/reckless
@@ -1563,6 +1563,8 @@ def _get_all_plugins_from_source(src: str) -> list:
         log.debug(f"Failed to populate source {src}: {e}")
         return plugins
 
+    plugins.append((root.name, src))
+    
     for item in root.contents:
         if isinstance(item, SourceDir):
             # Skip archive directories


### PR DESCRIPTION
Changelog-Fixed: reckless search now returns partial matches instead of requiring exact plugin names.

> [!IMPORTANT]
>
> 25.12 FREEZE October 27th: Non-bugfix PRs not ready by this date will wait for 26.03.
>
> RC1 is scheduled on _November 10th_
>
> The final release is scheduled for December 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
